### PR TITLE
Vite support

### DIFF
--- a/src/form-components-pro-vue3-tailwind3-simple/src/choices.scss
+++ b/src/form-components-pro-vue3-tailwind3-simple/src/choices.scss
@@ -1,6 +1,6 @@
 $choices-bg-color: white;
 
-@import "node_modules/choices.js/src/styles/choices";
+@import "choices.js/src/styles/choices";
 
 span+.#{$choices-selector} {
     @apply mt-1;

--- a/src/form-components-pro-vue3-tailwind3-simple/src/choices.scss
+++ b/src/form-components-pro-vue3-tailwind3-simple/src/choices.scss
@@ -1,6 +1,6 @@
 $choices-bg-color: white;
 
-@import "~choices.js/src/styles/choices";
+@import "node_modules/choices.js/src/styles/choices";
 
 span+.#{$choices-selector} {
     @apply mt-1;


### PR DESCRIPTION
Hey! 👋

I recently switched from webpack to Vite and ran into an import issue. Vite does not recognize `~` for imports and I haven't managed to get it working with an alias for some reason.

Prepending module paths with a tilde tells webpack to search through the node_modules folder, but it seems like it is also deprecated in webpack. https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules

This PR simply removes `~` at the start of the import, tested on both webpack and vite projects.